### PR TITLE
Improve installation instructions

### DIFF
--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -21,6 +21,7 @@ Please, refer also https://www.projectforge.org/documentation.html[www.projectfo
 |Document | Description
 |link:development{outfilesuffix}[Development]|Development docs.
 |link:migration{outfilesuffix}[Migration]|Migration guide.
+|link:installation{outfilesuffix}[Installation]|Installation docs.
 |link:deployment{outfilesuffix}[Deployment]|How to deploy a new release.
 |link:license{outfilesuffix}[License]| GNU GENERAL PUBLIC LICENSE, Version 3
 |=======

--- a/doc/installation.adoc
+++ b/doc/installation.adoc
@@ -11,32 +11,65 @@ link:index{outfilesuffix}[Top]
 
 :sectnums:
 
-== Use SSL
+== Reverse Proxy Setup
+
+The recommended way of setting up ProjectForge is to use a reverse proxy to do the SSL termination. This document focueses on using the NGINX web server software to  accomplish this.
+
 === Nginx
 ==== Prepare
-1. Install Nginx: `apt-get install nginx`
-2. Create certificate: `openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/projectforge.key -out /etc/ssl/projectforge.crt`
 
-==== Optional (secure domain for setup through htpasswd)
-1. `apt-get install apache2-utils`
-2. `htpasswd -c /etc/nginx/.htpasswd projectforge`
+All of the commands below should be run with `root` privileges.
+
+1. Install Nginx: `$ apt-get install nginx`
+2. Get an SSL certificate(use only one of the options below)
+2.1 Create self signed certificate: `$ openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/projectforge.key -out /etc/ssl/projectforge.crt`
+2.2 Generate an SSL certificate https://letsencrypt.org/getting-started/[using Letsencrypt], note that the path in the NGINX configuration below needs to be changed when using Letsencrypt.
+3. Generate secure Diffie-Hellman parameters for key exchange (this will take a long time): `$ openssl dhparam -out /etc/nginx/dhparam.pem 4096`
+
+===== secure domain for setup through htpasswd (optional)
+1. `$ apt-get install apache2-utils`
+2. `$ htpasswd -c /etc/nginx/.htpasswd projectforge`
 
 ==== Configure Nginx
 
-./etc/nginx/sites-enabled/projectforge
+To use NGINX as a reverse proxy, it's necessary to create a configuration file. The standard path for NGINX configurations is `/etc/nginx/sites-available/`, so let's create the file `/etc/nginx/sites-available/projectforge` with the content listed below. 
+If you want to use `.htaccess` to blok access to the installation, you need to remove the comment character (`#`) in front of the `auth_basic` and `auth_basic_file` parameters.
+If you want to use HSTS (which makes browsers show an error page when the SSL certificate is invalid and/or nonexistent), remove the comment character (`#`) in front of the `add_header Strict-Transport-Security` parameter.
+
+**Remeber to replace *projectforge.example.com* with the actual domain you'll run ProjectForge on!**
+
 [source]
 ----
 server {
   listen 80;
-  return 301 https://$host$request_uri;
+  listen [::]:80;
+  server_name projectforge.example.com;
+  location / { return 301 https://$host$request_uri; }
 }
 
 server {
-  listen              443;
-  server_name         projectforge.acme.com;
+  listen              443 ssl;
+  listen              [::]:443 ssl;
+  server_name         projectforge.example.com;
   ssl_certificate     /etc/ssl/projectforge.crt;
   ssl_certificate_key /etc/ssl/projectforge.key;
   ssl on;
+  
+  ssl_protocols TLSv1.2;
+  ssl_prefer_server_ciphers on; 
+  ssl_dhparam /etc/nginx/dhparam.pem;
+  ssl_ciphers EECDH+AESGCM:EDH+AESGCM;
+  ssl_ecdh_curve secp384r1; # Requires nginx >= 1.1.0
+  ssl_session_timeout  10m;
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_tickets off; # Requires nginx >= 1.5.9
+  ssl_stapling on; # Requires nginx >= 1.3.7
+  ssl_stapling_verify on; # Requires nginx => 1.3.7
+  add_header X-Frame-Options DENY;
+  add_header X-Content-Type-Options nosniff;
+  add_header X-XSS-Protection "1; mode=block";
+  
+  #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
 
   location / {
     proxy_set_header        Host $host;
@@ -46,7 +79,7 @@ server {
 
     proxy_pass              http://localhost:8080;
     proxy_read_timeout      90;
-    proxy_redirect          http://localhost:8080 https://projectforge.acme.com;
+    proxy_redirect          http://localhost:8080 https://projectforge.example.com;
 
     # auth_basic            "Username and Password Required";
     # auth_basic_user_file  /etc/nginx/.htpasswd;
@@ -54,8 +87,16 @@ server {
 }
 ----
 
-==== Start
-1. Start ProjectForge server (e. g. on `http://localhost:8080`).
+To activate the NGINX configuration, you'll need to symlink the configuration file we just created to `/etc/nginx/sites-enabled`. This can be done by using the following command: 
+
+```bash
+$ ln -sv /etc/nginx/sites-available/projectforge /etc/nginx/sites-enabled/projectforge
+```
+
+== Start ProjectForge
+1. Start ProjectForge server (e.g. on `http://localhost:8080`, update the NGINX config if you use another port).
 2. Follow the configuration instruction (setup wizard in console ui or as Desktop app).
-3. (Re-)start Nginx: `/etc/init.d/nginx restart`
-4. Use ProjectForge with your browser and finalize the setup.
+3. (Re-)start Nginx:
+3.1. SysVInit: `/etc/init.d/nginx restart`
+3.2. SystemD: `systemctl restart nginx`
+4. Navigate to ProjectForge with your browser and finalize the setup.


### PR DESCRIPTION
Hi,
this PR modifies the `installation.adoc` document in the following way:
- Add link to Letsencrypt in SSL setup instructions
- Add instruction to generate Diffie-Hellman params
- Fix heading level throughout the document
- Add optional [HSTS](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) configuration (and instructions on how to enable it)
- Add hardened SSL config (according to [cipherli.st](https://cipherli.st) best practices, tweaked for legacy (i.e. TLS1.2) support)
- Add recommended headers like `X-Frame-Options`, `X-XSS-Protection`, etc.
- Make NGINX listen on IPv6 too
- Add restart instruction for Systemd

Additionally, I've added a link to the installation document to the `README.adoc` file.