### PR TITLE
  Improve WebAuthn authentication experience and device compatibility

### DIFF
--- a/projectforge-rest/src/main/kotlin/org/projectforge/security/WebAuthnServicesRest.kt
+++ b/projectforge-rest/src/main/kotlin/org/projectforge/security/WebAuthnServicesRest.kt
@@ -215,10 +215,10 @@ class WebAuthnServicesRest {
       PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.RS256),
     )
 
-  // CROSS_PLATFORM: required for support of mobile phones etc.
+  // Allow both platform (Touch ID, Windows Hello) and cross-platform (USB keys) authenticators
   private val authenticatorSelectionCriteria: AuthenticatorSelectionCriteria
     get() = AuthenticatorSelectionCriteria(
-      AuthenticatorAttachment.CROSS_PLATFORM,
+      null, // null allows both PLATFORM and CROSS_PLATFORM authenticators
       false,
       UserVerificationRequirement.PREFERRED
     )

--- a/projectforge-webapp/src/components/base/dynamicLayout/components/customized/components/WebAuthnAuthenticate.jsx
+++ b/projectforge-webapp/src/components/base/dynamicLayout/components/customized/components/WebAuthnAuthenticate.jsx
@@ -12,6 +12,7 @@ import { DynamicLayoutContext } from '../../../context';
 
 function WebAuthn({ values }) {
     const { ui, data, callAction } = React.useContext(DynamicLayoutContext);
+    const [authenticationStarted, setAuthenticationStarted] = React.useState(false);
 
     const finishAuthenticate = async (publicKeyCredentialCreationOptions) => {
         const createRequest = convertPublicKeyCredentialRequestOptions(publicKeyCredentialCreationOptions);
@@ -27,6 +28,7 @@ function WebAuthn({ values }) {
     };
 
     const authenticate = () => {
+        setAuthenticationStarted(true);
         fetchJsonGet(
             values.authenticateUrl || 'webauthn/webAuthn',
             {},
@@ -35,6 +37,14 @@ function WebAuthn({ values }) {
             },
         );
     };
+
+    // Auto-start WebAuthn authentication when component mounts, but only for login context
+    // (when authenticateUrl is explicitly provided, indicating this is the public login service)
+    React.useEffect(() => {
+        if (!authenticationStarted && values.authenticateUrl) {
+            authenticate();
+        }
+    }, []);
 
     return (
         <>


### PR DESCRIPTION
WebAuthn Device Support:
- Allow both platform (Touch ID, Windows Hello) and cross-platform (USB keys) authenticators
- Changed authenticatorSelectionCriteria from CROSS_PLATFORM only to null (supports both)
- Improves compatibility with various authentication devices

WebAuthn Authentication:
- Auto-start WebAuthn authentication on login page when user has registered devices
- Added state management to prevent duplicate authentication attempts
- Only auto-trigger on login context (when authenticateUrl is provided)
- Manual authentication button remains available in all contexts
