### PR TITLE
Upgrade Java version to 21

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,10 +19,10 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/checkout@v3
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Cache Gradle dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim
+FROM openjdk:21-slim
 
 # Argument for JAR file name to use in working directory:
 ARG JAR_FILE

--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,7 @@ Or simply use the fastest way: https://projectforge.org/docs/installation/[Insta
 ====
 
 1. Checkout: `git clone git@github.com:micromata/projectforge.git`
-2. For developing try OpenJDK 17 (tested): `java -version`.
+2. For developing try OpenJDK 21 (tested): `java -version`.
 3. Build ProjectForge:
    `./gradlew build -x test` (or `./gradlew.bat build -x test` on Windows)
 4. Run ProjectForge:
@@ -58,8 +58,8 @@ To configure a different directory you have several options (*choose Your favori
 
 Please note the detailed documentations for administrators, developers as well as for users.
 
-Java version 17 is required since ProjectForge 8.0.
-Please note, that OpenJdk 17 is currently used in production for developing and running ProjectForge.
+Java version 21 is required since ProjectForge 8.1.
+Please note, that OpenJdk 21 is currently used in production for developing and running ProjectForge.
 
 === Quickstart with IntelliJ
 

--- a/buildSrc/src/main/kotlin/buildlogic.pf-module-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.pf-module-conventions.gradle.kts
@@ -18,8 +18,8 @@ group = "org.projectforge"
 version = libs.findVersion("org.projectforge").get().requiredVersion
 
 extensions.configure<JavaPluginExtension> {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 tasks.withType<JavaCompile> {

--- a/doc/Testinstallation-deutsch.adoc
+++ b/doc/Testinstallation-deutsch.adoc
@@ -6,8 +6,8 @@ Die aktuellste Version dieser Datei befindet sich https://github.com/micromata/p
 
 `projectforge-application-8.1-xxx.jar` herunterladen
 
-===== Java 17 installieren
-Open-JDK 17 installieren bzw. entsprechendes Docker-Image verwenden.
+===== Java 21 installieren
+Open-JDK 21 installieren bzw. entsprechendes Docker-Image verwenden.
 
 ==== Erststart
 

--- a/plugins/org.projectforge.plugins.banking/build.gradle.kts
+++ b/plugins/org.projectforge.plugins.banking/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/plugins/org.projectforge.plugins.datatransfer/build.gradle.kts
+++ b/plugins/org.projectforge.plugins.datatransfer/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/plugins/org.projectforge.plugins.ihk/build.gradle.kts
+++ b/plugins/org.projectforge.plugins.ihk/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/plugins/org.projectforge.plugins.licensemanagement/build.gradle.kts
+++ b/plugins/org.projectforge.plugins.licensemanagement/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/plugins/org.projectforge.plugins.liquidityplanning/build.gradle.kts
+++ b/plugins/org.projectforge.plugins.liquidityplanning/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/plugins/org.projectforge.plugins.marketing/build.gradle.kts
+++ b/plugins/org.projectforge.plugins.marketing/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/plugins/org.projectforge.plugins.memo/build.gradle.kts
+++ b/plugins/org.projectforge.plugins.memo/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/plugins/org.projectforge.plugins.merlin/build.gradle.kts
+++ b/plugins/org.projectforge.plugins.merlin/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/plugins/org.projectforge.plugins.skillmatrix/build.gradle.kts
+++ b/plugins/org.projectforge.plugins.skillmatrix/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/plugins/org.projectforge.plugins.todo/build.gradle.kts
+++ b/plugins/org.projectforge.plugins.todo/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/projectforge-application/build.gradle.kts
+++ b/projectforge-application/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/projectforge-business/build.gradle.kts
+++ b/projectforge-business/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/projectforge-carddav/build.gradle.kts
+++ b/projectforge-carddav/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/projectforge-common/build.gradle.kts
+++ b/projectforge-common/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/projectforge-commons-test/build.gradle.kts
+++ b/projectforge-commons-test/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/projectforge-jcr/build.gradle.kts
+++ b/projectforge-jcr/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/projectforge-model/build.gradle.kts
+++ b/projectforge-model/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/projectforge-rest/build.gradle.kts
+++ b/projectforge-rest/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 

--- a/projectforge-wicket/build.gradle.kts
+++ b/projectforge-wicket/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }
 


### PR DESCRIPTION
Upgrade Java version to 21
- Change target vm in build configuration
- Change java version in Dockerfile
- Update documentation

Applied some rudementary testing on local machines. More extensive testing is recommended before releasing this upgrade. 
It might also be necessary to update server infrastructure depending on how PF is hosted.